### PR TITLE
feat: add kubernetes deployments for all services

### DIFF
--- a/deployments/kubernetes/README.md
+++ b/deployments/kubernetes/README.md
@@ -1,0 +1,38 @@
+# Kubernetes Manifests
+
+This folder contains the Kubernetes manifests for the full booking stack:
+
+- `identity`
+- `flight`
+- `passenger`
+- `booking`
+- `postgres`
+- `rabbitmq`
+- `otel-collector`
+- `jaeger`
+- `zipkin`
+
+## Apply
+
+From the repo root:
+
+```bash
+kubectl apply -k deployments/kubernetes
+```
+
+## Ingress
+
+The ingress routes requests by path on `booking.local`:
+
+- `/identity`
+- `/flight`
+- `/passenger`
+- `/booking`
+
+If you are testing locally, point `booking.local` to your ingress controller address.
+
+## Notes
+
+- The app images are referenced by the local tags produced by the Dockerfiles.
+- Postgres and RabbitMQ use persistent volume claims.
+- The app services read their runtime configuration from the shared ConfigMap and Secret.

--- a/deployments/kubernetes/booking-deployment.yaml
+++ b/deployments/kubernetes/booking-deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: booking
+  namespace: booking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: booking
+  template:
+    metadata:
+      labels:
+        app: booking
+    spec:
+      containers:
+        - name: booking
+          # image: booking-microservices-expressjs-booking:latest
+          image : booking-service:latest 
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: booking-config
+            - secretRef:
+                name: booking-secret
+          env:
+            - name: PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: BOOKING_PORT
+            - name: SERVICE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: BOOKING_SERVICE_NAME
+            - name: POSTGRES_Database
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: POSTGRES_DB
+            - name: RABBITMQ_EXCHANGE
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: BOOKING_RABBITMQ_EXCHANGE
+            - name: OPEN_TELEMETRY_SERVICE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: BOOKING_OTEL_SERVICE_NAME
+          ports:
+            - containerPort: 3366
+              name: http
+          startupProbe:
+            httpGet:
+              path: /
+              port: 3366
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3366
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3366
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5

--- a/deployments/kubernetes/booking-service.yaml
+++ b/deployments/kubernetes/booking-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: booking
+  namespace: booking
+spec:
+  type: ClusterIP
+  selector:
+    app: booking
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3366
+      protocol: TCP

--- a/deployments/kubernetes/configmap.yaml
+++ b/deployments/kubernetes/configmap.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: booking-config
+  namespace: booking
+data:
+  NODE_ENV: production
+  POSTGRES_HOST: postgres
+  POSTGRES_PORT: "5432"
+  POSTGRES_USER: postgres
+  POSTGRES_USERNAME: postgres
+  POSTGRES_SYNCHRONIZE: "false"
+  POSTGRES_ENTITIES: /../**/*.entity.{js,ts}
+  POSTGRES_MIGRATIONS: /../**/data/migrations/*.{js,ts}
+  POSTGRES_DB: booking
+  RABBITMQ_Host: rabbitmq
+  RABBITMQ_PORT: "5672"
+  RABBITMQ_DEFAULT_USER: guest
+  RABBITMQ_USERNAME: guest
+  OPEN_TELEMETRY_COLLECTOR_URL: http://otel-collector:4319
+  IDENTITY_PORT: "3333"
+  IDENTITY_SERVICE_NAME: identity-service
+  IDENTITY_RABBITMQ_EXCHANGE: identity
+  IDENTITY_OTEL_SERVICE_NAME: identity
+  FLIGHT_PORT: "3344"
+  FLIGHT_SERVICE_NAME: flight-service
+  FLIGHT_RABBITMQ_EXCHANGE: flight
+  FLIGHT_OTEL_SERVICE_NAME: flight
+  PASSENGER_PORT: "3355"
+  PASSENGER_SERVICE_NAME: passenger-service
+  PASSENGER_RABBITMQ_EXCHANGE: passenger
+  PASSENGER_OTEL_SERVICE_NAME: passenger
+  BOOKING_PORT: "3366"
+  BOOKING_SERVICE_NAME: booking-service
+  BOOKING_RABBITMQ_EXCHANGE: booking
+  BOOKING_OTEL_SERVICE_NAME: booking

--- a/deployments/kubernetes/flight-deployment.yaml
+++ b/deployments/kubernetes/flight-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flight
+  namespace: booking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: flight
+  template:
+    metadata:
+      labels:
+        app: flight
+    spec:
+      containers:
+        - name: flight
+          image: booking-microservices-expressjs-flight:latest
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: booking-config
+            - secretRef:
+                name: booking-secret
+          env:
+            - name: PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: FLIGHT_PORT
+            - name: SERVICE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: FLIGHT_SERVICE_NAME
+            - name: POSTGRES_Database
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: POSTGRES_DB
+            - name: RABBITMQ_EXCHANGE
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: FLIGHT_RABBITMQ_EXCHANGE
+            - name: OPEN_TELEMETRY_SERVICE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: FLIGHT_OTEL_SERVICE_NAME
+          ports:
+            - containerPort: 3344
+              name: http
+          startupProbe:
+            httpGet:
+              path: /
+              port: 3344
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3344
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3344
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5

--- a/deployments/kubernetes/flight-service.yaml
+++ b/deployments/kubernetes/flight-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: flight
+  namespace: booking
+spec:
+  type: ClusterIP
+  selector:
+    app: flight
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3344
+      protocol: TCP

--- a/deployments/kubernetes/identity-deployment.yaml
+++ b/deployments/kubernetes/identity-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  namespace: booking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: identity
+  template:
+    metadata:
+      labels:
+        app: identity
+    spec:
+      containers:
+        - name: identity
+          image: booking-microservices-expressjs-identity:latest
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: booking-config
+            - secretRef:
+                name: booking-secret
+          env:
+            - name: PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: IDENTITY_PORT
+            - name: SERVICE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: IDENTITY_SERVICE_NAME
+            - name: POSTGRES_Database
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: POSTGRES_DB
+            - name: RABBITMQ_EXCHANGE
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: IDENTITY_RABBITMQ_EXCHANGE
+            - name: OPEN_TELEMETRY_SERVICE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: IDENTITY_OTEL_SERVICE_NAME
+          ports:
+            - containerPort: 3333
+              name: http
+          startupProbe:
+            httpGet:
+              path: /
+              port: 3333
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3333
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3333
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5

--- a/deployments/kubernetes/identity-service.yaml
+++ b/deployments/kubernetes/identity-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  namespace: booking
+spec:
+  type: ClusterIP
+  selector:
+    app: identity
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3333
+      protocol: TCP

--- a/deployments/kubernetes/ingress.yaml
+++ b/deployments/kubernetes/ingress.yaml
@@ -1,0 +1,42 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: booking
+  namespace: booking
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: booking.local
+      http:
+        paths:
+          - path: /identity(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: identity
+                port:
+                  number: 80
+          - path: /flight(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: flight
+                port:
+                  number: 80
+          - path: /passenger(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: passenger
+                port:
+                  number: 80
+          - path: /booking(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: booking
+                port:
+                  number: 80

--- a/deployments/kubernetes/jaeger-deployment.yaml
+++ b/deployments/kubernetes/jaeger-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  namespace: booking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jaeger
+  template:
+    metadata:
+      labels:
+        app: jaeger
+    spec:
+      containers:
+        - name: jaeger
+          image: jaegertracing/all-in-one:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 16686
+              name: ui

--- a/deployments/kubernetes/jaeger-service.yaml
+++ b/deployments/kubernetes/jaeger-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger
+  namespace: booking
+spec:
+  type: ClusterIP
+  selector:
+    app: jaeger
+  ports:
+    - name: ui
+      port: 16686
+      targetPort: 16686
+      protocol: TCP

--- a/deployments/kubernetes/kustomization.yaml
+++ b/deployments/kubernetes/kustomization.yaml
@@ -1,0 +1,26 @@
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret.yaml
+  - otel-collector-configmap.yaml
+  - otel-collector-deployment.yaml
+  - otel-collector-service.yaml
+  - postgres-pvc.yaml
+  - postgres-deployment.yaml
+  - postgres-service.yaml
+  - rabbitmq-pvc.yaml
+  - rabbitmq-deployment.yaml
+  - rabbitmq-service.yaml
+  - jaeger-deployment.yaml
+  - jaeger-service.yaml
+  - zipkin-deployment.yaml
+  - zipkin-service.yaml
+  - identity-deployment.yaml
+  - identity-service.yaml
+  - flight-deployment.yaml
+  - flight-service.yaml
+  - passenger-deployment.yaml
+  - passenger-service.yaml
+  - booking-deployment.yaml
+  - booking-service.yaml
+  - ingress.yaml

--- a/deployments/kubernetes/namespace.yaml
+++ b/deployments/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: booking

--- a/deployments/kubernetes/otel-collector-configmap.yaml
+++ b/deployments/kubernetes/otel-collector-configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: booking
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4319
+          http:
+            endpoint: 0.0.0.0:4320
+
+    processors:
+      batch:
+
+    exporters:
+      zipkin:
+        endpoint: http://zipkin:9411/api/v2/spans
+      debug:
+        verbosity: normal
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [zipkin, debug]
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]

--- a/deployments/kubernetes/otel-collector-deployment.yaml
+++ b/deployments/kubernetes/otel-collector-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: booking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:latest
+          imagePullPolicy: IfNotPresent
+          args: ["--config=/etc/otelcol-contrib/config.yaml"]
+          ports:
+            - containerPort: 4319
+              name: grpc
+            - containerPort: 4320
+              name: http
+          volumeMounts:
+            - name: otel-config
+              mountPath: /etc/otelcol-contrib/config.yaml
+              subPath: config.yaml
+      volumes:
+        - name: otel-config
+          configMap:
+            name: otel-collector-config

--- a/deployments/kubernetes/otel-collector-service.yaml
+++ b/deployments/kubernetes/otel-collector-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: booking
+spec:
+  type: ClusterIP
+  selector:
+    app: otel-collector
+  ports:
+    - name: grpc
+      port: 4319
+      targetPort: 4319
+      protocol: TCP
+    - name: http
+      port: 4320
+      targetPort: 4320
+      protocol: TCP

--- a/deployments/kubernetes/passenger-deployment.yaml
+++ b/deployments/kubernetes/passenger-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: passenger
+  namespace: booking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: passenger
+  template:
+    metadata:
+      labels:
+        app: passenger
+    spec:
+      containers:
+        - name: passenger
+          image: booking-microservices-expressjs-passenger:latest
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: booking-config
+            - secretRef:
+                name: booking-secret
+          env:
+            - name: PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: PASSENGER_PORT
+            - name: SERVICE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: PASSENGER_SERVICE_NAME
+            - name: POSTGRES_Database
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: POSTGRES_DB
+            - name: RABBITMQ_EXCHANGE
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: PASSENGER_RABBITMQ_EXCHANGE
+            - name: OPEN_TELEMETRY_SERVICE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: booking-config
+                  key: PASSENGER_OTEL_SERVICE_NAME
+          ports:
+            - containerPort: 3355
+              name: http
+          startupProbe:
+            httpGet:
+              path: /
+              port: 3355
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3355
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3355
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5

--- a/deployments/kubernetes/passenger-service.yaml
+++ b/deployments/kubernetes/passenger-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: passenger
+  namespace: booking
+spec:
+  type: ClusterIP
+  selector:
+    app: passenger
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3355
+      protocol: TCP

--- a/deployments/kubernetes/postgres-deployment.yaml
+++ b/deployments/kubernetes/postgres-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: booking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: booking-config
+            - secretRef:
+                name: booking-secret
+          ports:
+            - containerPort: 5432
+              name: postgres
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-data

--- a/deployments/kubernetes/postgres-pvc.yaml
+++ b/deployments/kubernetes/postgres-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  namespace: booking
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/deployments/kubernetes/postgres-service.yaml
+++ b/deployments/kubernetes/postgres-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: booking
+spec:
+  type: ClusterIP
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP

--- a/deployments/kubernetes/rabbitmq-deployment.yaml
+++ b/deployments/kubernetes/rabbitmq-deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+  namespace: booking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:management
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: booking-config
+            - secretRef:
+                name: booking-secret
+          ports:
+            - containerPort: 5672
+              name: amqp
+            - containerPort: 15672
+              name: management
+          volumeMounts:
+            - name: rabbitmq-data
+              mountPath: /var/lib/rabbitmq
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - rabbitmq-diagnostics -q ping
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 12
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - rabbitmq-diagnostics -q ping
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 10
+            failureThreshold: 6
+      volumes:
+        - name: rabbitmq-data
+          persistentVolumeClaim:
+            claimName: rabbitmq-data

--- a/deployments/kubernetes/rabbitmq-pvc.yaml
+++ b/deployments/kubernetes/rabbitmq-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rabbitmq-data
+  namespace: booking
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/deployments/kubernetes/rabbitmq-service.yaml
+++ b/deployments/kubernetes/rabbitmq-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  namespace: booking
+spec:
+  type: ClusterIP
+  selector:
+    app: rabbitmq
+  ports:
+    - name: amqp
+      port: 5672
+      targetPort: 5672
+      protocol: TCP
+    - name: management
+      port: 15672
+      targetPort: 15672
+      protocol: TCP

--- a/deployments/kubernetes/secret.yaml
+++ b/deployments/kubernetes/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: booking-secret
+  namespace: booking
+type: Opaque
+stringData:
+  JWT_SECRET: thisisafakesecretchangeit
+  POSTGRES_PASSWORD: postgres
+  RABBITMQ_PASSWORD: guest
+  RABBITMQ_DEFAULT_PASS: guest

--- a/deployments/kubernetes/zipkin-deployment.yaml
+++ b/deployments/kubernetes/zipkin-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zipkin
+  namespace: booking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zipkin
+  template:
+    metadata:
+      labels:
+        app: zipkin
+    spec:
+      containers:
+        - name: zipkin
+          image: openzipkin/zipkin:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9411
+              name: http

--- a/deployments/kubernetes/zipkin-service.yaml
+++ b/deployments/kubernetes/zipkin-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zipkin
+  namespace: booking
+spec:
+  type: ClusterIP
+  selector:
+    app: zipkin
+  ports:
+    - name: http
+      port: 9411
+      targetPort: 9411
+      protocol: TCP


### PR DESCRIPTION
Closes #10

## Summary
Add Kubernetes manifests for the full stack.

## What's included
- Separate Deployment + Service for each microservice: identity, booking, passenger, flight
- Deployment + Service (+ PVC) for postgres
- Deployment + Service (+ PVC) for rabbitmq
- Deployment + Service for jaeger, zipkin, and otel-collector
- Namespace, ConfigMap, and Secret for shared/sensitive config
- Ingress as reverse proxy routing to all 4 app services
- kustomization.yaml for applying everything with `kubectl apply -k`

## Validation
- Tested locally on minikube (Docker driver)
- Verified all pods reach Running/Ready state in the `booking` namespace
- Verified ingress routes requests to the correct services
- Verified postgres and rabbitmq persist data via PVCs

Tested with:
\`\`\`
kubectl apply -k deployments/kubernetes/
kubectl get pods -n booking
\`\`\`